### PR TITLE
fix(server_defaults): fix server_defaults not defined

### DIFF
--- a/openldap/server.sls
+++ b/openldap/server.sls
@@ -14,6 +14,7 @@
    - require:
      - pkg: {{ openldap.server_pkg }}
 
+{% if 'server_defaults' in openldap %}
 {{ openldap.server_defaults }}:
   file.managed:
     - source: salt://openldap/files/slapd.default.jinja
@@ -24,6 +25,7 @@
     - makedirs: True
     - require:
       - pkg: {{ openldap.server_pkg }}
+{% endif %}
 
 slapd_service:
   service.running:


### PR DESCRIPTION
fixes:
```
minion:
    Data failed to compile:
----------
    Rendering SLS 'base:openldap.server' failed: Jinja variable 'dict object' has no attribute 'server_defaults'
ERROR: Minions returned with non-zero exit code

```
on OSes where default file is not present